### PR TITLE
Do not allow empty uri field

### DIFF
--- a/__tests__/manifest.schema.test.js
+++ b/__tests__/manifest.schema.test.js
@@ -1,5 +1,5 @@
 'use strict';
- 
+
 const { validate } = require('../lib');
 
 /**
@@ -16,6 +16,10 @@ test('manifest.uri - contains absolute URI with https scheme - should not return
 
 test('manifest.uri - contains relative URI - should not return error', () => {
     expect(validate.uri('/metadata').error).toBe(false);
+});
+
+test('manifest.uri - empty - should return error', () => {
+    expect(validate.uri('').error).toBeTruthy();
 });
 
 /**

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -26,7 +26,7 @@ const manifest = createValidator(manifestSchema, {
     removeAdditional: true,
     useDefaults: true,
 });
-const uri = createValidator({ type: 'string', format: 'uri-reference' });
+const uri = createValidator({type: 'string', format: 'uri-reference', 'minLength': 1})
 const name = withTrimmer(createValidator(manifestSchema.properties.name));
 const version = withTrimmer(createValidator(manifestSchema.properties.version));
 const content = createValidator(manifestSchema.properties.content);


### PR DESCRIPTION
A URI field should not be allowed to be empty.

Fixes: https://github.com/podium-lib/layout/pull/31 and https://github.com/podium-lib/podlet/pull/21