### PR TITLE
Add js and css to root of schema

### DIFF
--- a/__tests__/manifest.schema.test.js
+++ b/__tests__/manifest.schema.test.js
@@ -1,5 +1,5 @@
 'use strict';
- 
+
 const { validate } = require('../lib');
 
 /**
@@ -200,12 +200,158 @@ test('manifest.schema - contains valid schema - should not return error', () => 
             js: 'http://www.finn.no/podlet/js',
             css: 'http://www.finn.no/podlet/css',
         },
+        css: [],
+        js: [],
         proxy: {
             a: 'http://www.finn.no/foo',
         },
         team: 'The A-Team',
     };
     expect(validate.manifest(schema).error).toBe(false);
+});
+
+test('manifest.schema - css and js is array of uris - should not return error', () => {
+    const schema = {
+        name: 'foo-bar',
+        version: '1.0.0',
+        content: 'http://www.finn.no/content',
+        fallback: 'http://www.finn.no/fallback',
+        assets: {
+            js: 'http://www.finn.no/podlet/js',
+            css: 'http://www.finn.no/podlet/css',
+        },
+        css: [
+            'http://www.finn.no/podlet/css/a',
+            'http://www.finn.no/podlet/css/b',
+        ],
+        js: [
+            'http://www.finn.no/podlet/js/a',
+            'http://www.finn.no/podlet/js/b',
+        ],
+        proxy: {
+            a: 'http://www.finn.no/foo',
+        },
+        team: 'The A-Team',
+    };
+    expect(validate.manifest(schema).error).toBe(false);
+});
+
+test('manifest.schema - css and js is array of objects - should not return error', () => {
+    const schema = {
+        name: 'foo-bar',
+        version: '1.0.0',
+        content: 'http://www.finn.no/content',
+        fallback: 'http://www.finn.no/fallback',
+        assets: {
+            js: 'http://www.finn.no/podlet/js',
+            css: 'http://www.finn.no/podlet/css',
+        },
+        css: [
+            { value: 'http://www.finn.no/podlet/css/a' },
+            { value: 'http://www.finn.no/podlet/css/b' },
+        ],
+        js: [
+            { value: 'http://www.finn.no/podlet/js/a' },
+            { value: 'http://www.finn.no/podlet/js/b' },
+        ],
+        proxy: {
+            a: 'http://www.finn.no/foo',
+        },
+        team: 'The A-Team',
+    };
+    expect(validate.manifest(schema).error).toBe(false);
+});
+
+test('manifest.schema - css is not an array - should return error', () => {
+    const schema = {
+        name: 'foo-bar',
+        version: '1.0.0',
+        content: 'http://www.finn.no/content',
+        fallback: 'http://www.finn.no/fallback',
+        assets: {
+            js: 'http://www.finn.no/podlet/js',
+            css: 'http://www.finn.no/podlet/css',
+        },
+        css: '',
+        js: [
+            { value: 'http://www.finn.no/podlet/js/a' },
+            { value: 'http://www.finn.no/podlet/js/b' },
+        ],
+        proxy: {
+            a: 'http://www.finn.no/foo',
+        },
+        team: 'The A-Team',
+    };
+    expect(validate.manifest(schema).error).toBeTruthy();
+});
+
+test('manifest.schema - js is not an array - should return error', () => {
+    const schema = {
+        name: 'foo-bar',
+        version: '1.0.0',
+        content: 'http://www.finn.no/content',
+        fallback: 'http://www.finn.no/fallback',
+        assets: {
+            js: 'http://www.finn.no/podlet/js',
+            css: 'http://www.finn.no/podlet/css',
+        },
+        css: [
+            { value: 'http://www.finn.no/podlet/css/a' },
+            { value: 'http://www.finn.no/podlet/css/b' },
+        ],
+        js: '',
+        proxy: {
+            a: 'http://www.finn.no/foo',
+        },
+        team: 'The A-Team',
+    };
+    expect(validate.manifest(schema).error).toBeTruthy();
+});
+
+test('manifest.schema - css contain illegal types - should return error', () => {
+    const schema = {
+        name: 'foo-bar',
+        version: '1.0.0',
+        content: 'http://www.finn.no/content',
+        fallback: 'http://www.finn.no/fallback',
+        assets: {
+            js: 'http://www.finn.no/podlet/js',
+            css: 'http://www.finn.no/podlet/css',
+        },
+        css: [1, true],
+        js: [
+            { value: 'http://www.finn.no/podlet/js/a' },
+            { value: 'http://www.finn.no/podlet/js/b' },
+        ],
+        proxy: {
+            a: 'http://www.finn.no/foo',
+        },
+        team: 'The A-Team',
+    };
+    expect(validate.manifest(schema).error).toBeTruthy();
+});
+
+test('manifest.schema - js is not an array - should return error', () => {
+    const schema = {
+        name: 'foo-bar',
+        version: '1.0.0',
+        content: 'http://www.finn.no/content',
+        fallback: 'http://www.finn.no/fallback',
+        assets: {
+            js: 'http://www.finn.no/podlet/js',
+            css: 'http://www.finn.no/podlet/css',
+        },
+        css: [
+            { value: 'http://www.finn.no/podlet/css/a' },
+            { value: 'http://www.finn.no/podlet/css/b' },
+        ],
+        js: [[], false],
+        proxy: {
+            a: 'http://www.finn.no/foo',
+        },
+        team: 'The A-Team',
+    };
+    expect(validate.manifest(schema).error).toBeTruthy();
 });
 
 test('manifest.schema - contains invalid schema - should return error', () => {

--- a/lib/manifest.schema.json
+++ b/lib/manifest.schema.json
@@ -42,6 +42,40 @@
         "js": ""
       }
     },
+    "css": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "string",
+            "format": "uri-reference",
+            "minLength": 1
+          },
+          {
+            "type": "object",
+            "default": {}
+          }
+        ]
+      },
+      "default": []
+    },
+    "js": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "string",
+            "format": "uri-reference",
+            "minLength": 1
+          },
+          {
+            "type": "object",
+            "default": {}
+          }
+        ]
+      },
+      "default": []
+    },
     "proxy": {
       "type": "object",
       "default": {},


### PR DESCRIPTION
This solves: https://github.com/podium-lib/issues/issues/10

This adds `js` and `css` to the root of the schema. Both is an `Array` and can take uri `Strings` or `Objects` as values to the `Array`.

Its worth nothing that `assets` are currently kept in the schema to provide backwards compabillity. In the podium modules we should not use the `assets` any more.