### PR TITLE
Add validator for absolute URIs

### DIFF
--- a/__tests__/manifest.schema.test.js
+++ b/__tests__/manifest.schema.test.js
@@ -23,6 +23,26 @@ test('manifest.uri - empty - should return error', () => {
 });
 
 /**
+ * .uriAbsolute
+ */
+
+test('manifest.uriAbsolute - contains absolute URI with http scheme - should not return error', () => {
+    expect(validate.uriAbsolute('http://www.finn.no/metadata').error).toBe(false);
+});
+
+test('manifest.uriAbsolute - contains absolute URI with https scheme - should not return error', () => {
+    expect(validate.uriAbsolute('https://www.finn.no/metadata').error).toBe(false);
+});
+
+test('manifest.uriAbsolute - contains relative URI - should return error', () => {
+    expect(validate.uriAbsolute('/metadata').error).toBeTruthy();
+});
+
+test('manifest.uriAbsolute - empty - should return error', () => {
+    expect(validate.uriAbsolute('').error).toBeTruthy();
+});
+
+/**
  * .name
  */
 

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -26,6 +26,7 @@ const manifest = createValidator(manifestSchema, {
     removeAdditional: true,
     useDefaults: true,
 });
+const uriAbsolute = createValidator({type: 'string', format: 'uri'})
 const uri = createValidator({type: 'string', format: 'uri-reference', 'minLength': 1})
 const name = withTrimmer(createValidator(manifestSchema.properties.name));
 const version = withTrimmer(createValidator(manifestSchema.properties.version));
@@ -37,6 +38,7 @@ const proxy = createValidator(manifestSchema.properties.proxy);
 const team = createValidator(manifestSchema.properties.team);
 
 module.exports.manifest = manifest;
+module.exports.uriAbsolute = uriAbsolute;
 module.exports.uri = uri;
 module.exports.name = name;
 module.exports.version = version;


### PR DESCRIPTION
In the manifest all URI's can be both absolute and relative but when refering to the manifest in a podlet in the client we require an absolute URI. This implements a strict validator which only allows absolute URIs.

Needed to solve: https://github.com/podium-lib/client/pull/30