### PR TITLE
feat: Add css and js html attributes to schema

### DIFF
--- a/lib/manifest.schema.json
+++ b/lib/manifest.schema.json
@@ -53,10 +53,34 @@
             "minLength": 1
           },
           "type": {
+            "type": "string",
+            "default": "text/css"
+          },
+          "crossorigin": {
+            "type": "string"
+          },
+          "disabled": {
+            "type": "boolean",
+            "default": false
+          },
+          "hreflang": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "media": {
+            "type": "string"
+          },
+          "rel": {
+            "type": "string",
+            "default": "stylesheet"
+          },
+          "as": {
             "type": "string"
           }
         },
-        "required": ["value", "type"]
+        "required": ["value"]
       },
       "default": []
     },
@@ -72,9 +96,30 @@
           },
           "type": {
             "type": "string"
+          },
+          "referrerpolicy": {
+            "type": "string"
+          },
+          "crossorigin": {
+            "type": "string"
+          },
+          "integrity": {
+            "type": "string"
+          },
+          "nomodule": {
+            "type": "boolean",
+            "default": false
+          },
+          "async": {
+            "type": "boolean",
+            "default": false
+          },
+          "defer": {
+            "type": "boolean",
+            "default": false
           }
         },
-        "required": ["value", "type"]
+        "required": ["value"]
       },
       "default": []
     },

--- a/tests/validate.js
+++ b/tests/validate.js
@@ -325,30 +325,6 @@ test('manifest.schema - css object is missing value', (t) => {
     t.end();
 });
 
-test('manifest.schema - css object is missing type', (t) => {
-    const schema = {
-        name: 'foo-bar',
-        version: '1.0.0',
-        content: 'http://www.finn.no/content',
-        fallback: 'http://www.finn.no/fallback',
-        assets: {
-            js: 'http://www.finn.no/podlet/js',
-            css: 'http://www.finn.no/podlet/css',
-        },
-        css: [
-            { value: 'http://www.finn.no/podlet/css/a', type: 'module' },
-            { value: 'http://www.finn.no/podlet/css/b' },
-        ],
-        js: [],
-        proxy: {
-            a: 'http://www.finn.no/foo',
-        },
-        team: 'The A-Team',
-    };
-    t.true(validate.manifest(schema).error, 'should return error');
-    t.end();
-});
-
 test('manifest.schema - js object is missing value', (t) => {
     const schema = {
         name: 'foo-bar',
@@ -362,30 +338,6 @@ test('manifest.schema - js object is missing value', (t) => {
         css: [],
         js: [
             { type: 'module' },
-            { value: 'http://www.finn.no/podlet/js/b', type: 'module' },
-        ],
-        proxy: {
-            a: 'http://www.finn.no/foo',
-        },
-        team: 'The A-Team',
-    };
-    t.true(validate.manifest(schema).error, 'should return error');
-    t.end();
-});
-
-test('manifest.schema - js object is missing type', (t) => {
-    const schema = {
-        name: 'foo-bar',
-        version: '1.0.0',
-        content: 'http://www.finn.no/content',
-        fallback: 'http://www.finn.no/fallback',
-        assets: {
-            js: 'http://www.finn.no/podlet/js',
-            css: 'http://www.finn.no/podlet/css',
-        },
-        css: [],
-        js: [
-            { value: 'http://www.finn.no/podlet/js/a' },
             { value: 'http://www.finn.no/podlet/js/b', type: 'module' },
         ],
         proxy: {


### PR DESCRIPTION
This extends the schema to include the html attributes `<script>` and `<link>` tags can have to load js and css. It should now reflect whats given in the documentation for the [`podlet.js()`](https://podium-lib.io/docs/api/podlet#jsoptionsoptions) and [`podlet.css()`](https://podium-lib.io/docs/api/podlet#cssoptionsoptions) methods.

The intention of this is to be aligned with the API plus keeping a schema making it easier to develop clients for reading podlets in other languages than javascript.