### PR TITLE
feat: Adding support for proxy objects

### DIFF
--- a/schema/manifest.schema.json
+++ b/schema/manifest.schema.json
@@ -104,16 +104,41 @@
       },
       "default": []
     },
+
     "proxy": {
-      "type": "object",
+      "type": ["object", "array"],
       "default": {},
-      "maxProperties": 4,
-      "patternProperties": {
-        ".*": {
-          "type": "string",
-          "format": "uri-reference"
+      "anyOf": [
+        {
+          "type": "object",
+          "maxProperties": 4,
+          "patternProperties": {
+            ".*": {
+              "type": "string",
+              "format": "uri-reference"
+            }
+          }
+        },
+        {
+          "type": "array",
+          "maxItems": 4,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "target": {
+                "type": "string",
+                "format": "uri-reference",
+                "minLength": 1
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": ["target", "name"]
+          }
         }
-      }
+      ]
     },
     "team": {
       "type": "string",

--- a/src/validate.js
+++ b/src/validate.js
@@ -2,7 +2,9 @@ import Ajv from 'ajv';
 import formats from 'ajv-formats';
 import schema from './schema.js';
 
-const createValidator = (jsonSchema, ajvOptions) => {
+const createValidator = (jsonSchema, ajvOptions = {
+    allowUnionTypes: true,
+}) => {
     const ajv = new Ajv(ajvOptions);
     formats(ajv); // Needed to support "uri"
     const validate = ajv.compile({
@@ -25,6 +27,7 @@ const withTrimmer = validator => data =>
 
 export const manifest = createValidator(schema, {
     removeAdditional: true,
+    allowUnionTypes: true,
     useDefaults: true,
 });
 

--- a/tests/validate.js
+++ b/tests/validate.js
@@ -194,13 +194,94 @@ tap.test('manifest.css - empty array', (t) => {
 // .proxy
 //
 
-tap.test('manifest.proxy - empty object', (t) => {
-    t.notOk(proxy({}).error, 'should not return error');
+tap.test('manifest.proxy - empty array', (t) => {
+    t.notOk(proxy([]).error, 'should not return error');
     t.end();
 });
 
-tap.test('manifest.proxy - not object', (t) => {
+tap.test('manifest.proxy - not array or object', (t) => {
     t.ok(proxy('').error, 'should return error');
+    t.ok(proxy(2).error, 'should return error');
+    t.ok(proxy(true).error, 'should return error');
+    t.end();
+});
+
+tap.test('manifest.proxy - proxy item is valid object', (t) => {
+    const item = {
+        target: 'http://www.finn.no/foo',
+        name: 'foo',
+    };
+    t.notOk(proxy([item]).error, 'should not return error');
+    t.end();
+});
+
+tap.test('manifest.proxy - proxy item is invalid object', (t) => {
+    const item = {
+        foo: 'http://www.finn.no/foo',
+        bar: 'foo',
+    };
+    t.ok(proxy([item]).error, 'should return error');
+    t.end();
+});
+
+tap.test('manifest.proxy - proxy item is missing "name" property', (t) => {
+    const item = {
+        target: 'http://www.finn.no/foo',
+    };
+    t.ok(proxy([item]).error, 'should return error');
+    t.end();
+});
+
+tap.test('manifest.proxy - proxy item is missing "target" property', (t) => {
+    const item = {
+        name: "foo",
+    };
+    t.ok(proxy([item]).error, 'should return error');
+    t.end();
+});
+
+tap.test('manifest.proxy - proxy item has illegal value for "target" property', (t) => {
+    const item = {
+        target: 2,
+        name: "foo",
+    };
+    t.ok(proxy([item]).error, 'should return error');
+    t.end();
+});
+
+tap.test('manifest.proxy - proxy item has illegal value for "name" property', (t) => {
+    const item = {
+        target: 'http://www.finn.no/foo',
+        name: 2,
+    };
+    t.ok(proxy([item]).error, 'should return error');
+    t.end();
+});
+
+tap.test('manifest.proxy - proxy item has relative url for "target" property', (t) => {
+    const item = {
+        target: '/foo',
+        name: 'foo',
+    };
+    t.notOk(proxy([item]).error, 'should not return error');
+    t.end();
+});
+
+tap.test('manifest.proxy - proxy has more than 4 items', (t) => {
+    const item = {
+        target: 'http://www.finn.no/foo',
+        name: 'foo',
+    };
+    t.ok(proxy([item, item, item, item, item]).error, 'should return error');
+    t.end();
+});
+
+//
+// .proxy - LEGACY OBJECT SUPPORT
+//
+
+tap.test('manifest.proxy - empty object', (t) => {
+    t.notOk(proxy({}).error, 'should not return error');
     t.end();
 });
 


### PR DESCRIPTION
This adds support for proxy objects in the manifest file. This is added to version 5 so it can be fully adopted in version 6 and have a reasonable backwards compatibility.

Currently the `proxy` proxy field in the manifest is a plain object where the "name" of a proxy route is the property key in the object and the "target" is the value of the property. It looks like so:

```js
{
    proxy: {
        foo: 'http://some.destination.com/foo/bar'
    }
}
```

This is not optimal for multiple reasons:
 * Its not optimal for non JS languages to parse this
 * Its not optimal to use proxy names which contain non-legal property characters
 * it limits further features where one might want more than just the name and target of a proxy route (how to ex define timeout?)

This PR adds support for the proxy feature in the manifest to be an array of proxy objects as such:

```js
{
    proxy: [
        { name: 'bar', target: 'http://some.destination.com/bar' },
        { name: 'foo', target: 'http://some.destination.com/foo' },
    ]
}
```

Version 5 should not utilize this other than extending the manifest supporting how its done in version 4 (object only). Version 6 should adopt writing just arrays of object in the manifest. Version 7 should then remove the support for the object only version. 