### PR TITLE
feat: add asset strategy and scope fields

### DIFF
--- a/lib/manifest.schema.json
+++ b/lib/manifest.schema.json
@@ -78,6 +78,14 @@
           },
           "as": {
             "type": "string"
+          },
+          "strategy": {
+            "type": "string",
+            "pattern": "^lazy|beforeInteractive|afterInteractive$"
+          },
+          "scope": {
+            "type": "string",
+            "pattern": "^content|fallback|all$"
           }
         },
         "required": ["value"]
@@ -117,6 +125,14 @@
           "defer": {
             "type": "boolean",
             "default": false
+          },
+          "strategy": {
+            "type": "string",
+            "pattern": "^lazy|beforeInteractive|afterInteractive$"
+          },
+          "scope": {
+            "type": "string",
+            "pattern": "^content|fallback|all$"
           }
         },
         "required": ["value"]

--- a/tests/validate.js
+++ b/tests/validate.js
@@ -483,3 +483,110 @@ test('manifest.schema - optional fields not set - should set defaults', (t) => {
     t.same(res.value.proxy, {});
     t.end();
 });
+
+/* Assets strategy field */
+
+const testSchema = (schema) => ({
+    name: 'foo-bar',
+    version: '1.0.0',
+    content: 'http://www.finn.no/content',
+    ...schema,
+});
+
+test('manifest.schema - css - strategy - afterInteractive is valid', (t) => {
+    const schema = testSchema({ css: [{ value: 'http://www.finn.no/podlet/css/a', strategy: 'afterInteractive' }] });
+    t.equal(validate.manifest(schema).error, false, 'should not return error');
+    t.end();
+});
+test('manifest.schema - css - strategy - beforeInteractive is valid', (t) => {
+    const schema = testSchema({ css: [{ value: 'http://www.finn.no/podlet/css/a', strategy: 'beforeInteractive' }] });
+    t.equal(validate.manifest(schema).error, false, 'should not return error');
+    t.end();
+});
+test('manifest.schema - css - strategy - lazy is valid', (t) => {
+    const schema = testSchema({ css: [{ value: 'http://www.finn.no/podlet/css/a', strategy: 'lazy' }] });
+    t.equal(validate.manifest(schema).error, false, 'should not return error');
+    t.end();
+});
+
+test('manifest.schema - css - strategy - bar is not valid', (t) => {
+    const schema = testSchema({ css: [{ value: 'http://www.finn.no/podlet/css/a', strategy: 'bar' }] });
+    t.equal(validate.manifest(schema).error[0].instancePath, '/css/0/strategy', 'should match path');
+    t.equal(validate.manifest(schema).error[0].message, 'must match pattern "^lazy|beforeInteractive|afterInteractive$"', 'should match pattern');
+    t.end();
+});
+
+test('manifest.schema - js - strategy - afterInteractive is valid', (t) => {
+    const schema = testSchema({ js: [{ value: 'http://www.finn.no/podlet/js/a', strategy: 'afterInteractive' }] });
+    t.equal(validate.manifest(schema).error, false, 'should not return error');
+    t.end();
+});
+test('manifest.schema - js - strategy - beforeInteractive is valid', (t) => {
+    const schema = testSchema({ js: [{ value: 'http://www.finn.no/podlet/js/a', strategy: 'beforeInteractive' }] });
+    t.equal(validate.manifest(schema).error, false, 'should not return error');
+    t.end();
+});
+test('manifest.schema - js - strategy - lazy is valid', (t) => {
+    const schema = testSchema({ js: [{ value: 'http://www.finn.no/podlet/js/a', strategy: 'lazy' }] });
+    t.equal(validate.manifest(schema).error, false, 'should not return error');
+    t.end();
+});
+
+test('manifest.schema - js - strategy - bar is not valid', (t) => {
+    const schema = testSchema({ js: [{ value: 'http://www.finn.no/podlet/js/a', strategy: 'bar' }] });
+    t.equal(validate.manifest(schema).error[0].instancePath, '/js/0/strategy', 'should match path');
+    t.equal(validate.manifest(schema).error[0].message, 'must match pattern "^lazy|beforeInteractive|afterInteractive$"', 'should match pattern');
+    t.end();
+});
+
+/* Assets scope field */
+
+test('manifest.schema - css - scope - content is valid', (t) => {
+  const schema = testSchema({ css: [{ value: 'http://www.finn.no/podlet/css/a', scope: 'content' }] });
+  t.equal(validate.manifest(schema).error, false, 'should not return error');
+  t.end();
+});
+
+test('manifest.schema - css - scope - fallback is valid', (t) => {
+  const schema = testSchema({ css: [{ value: 'http://www.finn.no/podlet/css/a', scope: 'fallback' }] });
+  t.equal(validate.manifest(schema).error, false, 'should not return error');
+  t.end();
+});
+
+test('manifest.schema - css - scope - all is valid', (t) => {
+  const schema = testSchema({ css: [{ value: 'http://www.finn.no/podlet/css/a', scope: 'all' }] });
+  t.equal(validate.manifest(schema).error, false, 'should not return error');
+  t.end();
+});
+
+test('manifest.schema - css - scope - foo is not valid', (t) => {
+  const schema = testSchema({ css: [{ value: 'http://www.finn.no/podlet/css/a', scope: 'foo' }] });
+  t.equal(validate.manifest(schema).error[0].instancePath, '/css/0/scope', 'should match path');
+  t.equal(validate.manifest(schema).error[0].message, 'must match pattern "^content|fallback|all$"', 'should match pattern');
+  t.end();
+});
+
+test('manifest.schema - js - scope - content is valid', (t) => {
+  const schema = testSchema({ js: [{ value: 'http://www.finn.no/podlet/js/a', scope: 'content' }] });
+  t.equal(validate.manifest(schema).error, false, 'should not return error');
+  t.end();
+});
+
+test('manifest.schema - js - scope - fallback is valid', (t) => {
+  const schema = testSchema({ js: [{ value: 'http://www.finn.no/podlet/js/a', scope: 'fallback' }] });
+  t.equal(validate.manifest(schema).error, false, 'should not return error');
+  t.end();
+});
+
+test('manifest.schema - js - scope - all is valid', (t) => {
+  const schema = testSchema({ js: [{ value: 'http://www.finn.no/podlet/js/a', scope: 'all' }] });
+  t.equal(validate.manifest(schema).error, false, 'should not return error');
+  t.end();
+});
+
+test('manifest.schema - scope - js is not valid', (t) => {
+  const schema = testSchema({ js: [{ value: 'http://www.finn.no/podlet/js/a', scope: 'foo' }] });
+  t.equal(validate.manifest(schema).error[0].instancePath, '/js/0/scope', 'should match path');
+  t.equal(validate.manifest(schema).error[0].message, 'must match pattern "^content|fallback|all$"', 'should match pattern');
+  t.end();
+});


### PR DESCRIPTION
This PR extends the assets section of the podlet manifest file to make it possible to give more information to the layout about the assets provided by the podlet. Changes are backwards compatible.

### strategy
Strategy gives the layout a hint about when to load assets. We have used the same values as for the Next.js strategy option which are:
* **beforeInteractive** - load a script or css file before the page becomes interactive
* **afterInteractive** - load a script or css after the page becomes interactive
* **lazy** - lazy load this script or css

**Example**
```
{ value: "/path/to/file.js", strategy: "beforeInteractive" }
```

### scope
Scope can be used to give the layout information that can be used to determine IF an asset should be loaded at all.
Valid values are
* **content** - means "only load this asset if the current route is the content route"
* **fallback** - means "only load this asset if the current route is the fallback route"
* **all** (default if not provided and current behaviour prior to this change) - means load this asset regardless of which route

**Example**
```
{ value: "/path/to/file.js", scope: "content" }
```