### PR TITLE
feat: add shadow-dom strategy

### DIFF
--- a/schema/manifest.schema.json
+++ b/schema/manifest.schema.json
@@ -62,7 +62,7 @@
           },
           "strategy": {
             "type": "string",
-            "pattern": "^lazy|beforeInteractive|afterInteractive$"
+            "pattern": "^lazy|beforeInteractive|afterInteractive|shadow-dom$"
           },
           "scope": {
             "type": "string",
@@ -109,7 +109,7 @@
           },
           "strategy": {
             "type": "string",
-            "pattern": "^lazy|beforeInteractive|afterInteractive$"
+            "pattern": "^lazy|beforeInteractive|afterInteractive|shadow-dom$"
           },
           "scope": {
             "type": "string",

--- a/tests/validate.test.js
+++ b/tests/validate.test.js
@@ -687,7 +687,7 @@ tap.test('manifest.schema - css - strategy - bar is not valid', (t) => {
     );
     t.equal(
         manifest(schema).error[0].message,
-        'must match pattern "^lazy|beforeInteractive|afterInteractive$"',
+        'must match pattern "^lazy|beforeInteractive|afterInteractive|shadow-dom$"',
         'should match pattern',
     );
     t.end();
@@ -739,7 +739,7 @@ tap.test('manifest.schema - js - strategy - bar is not valid', (t) => {
     );
     t.equal(
         manifest(schema).error[0].message,
-        'must match pattern "^lazy|beforeInteractive|afterInteractive$"',
+        'must match pattern "^lazy|beforeInteractive|afterInteractive|shadow-dom$"',
         'should match pattern',
     );
     t.end();


### PR DESCRIPTION
The schema needs to support "shadow-dom" as an asset placement strategy in order to work along side the DSD feature.